### PR TITLE
Adds `hclq` to devcontainers, closes #9

### DIFF
--- a/src/Dockerfile.dev
+++ b/src/Dockerfile.dev
@@ -14,6 +14,11 @@ RUN apt update && apt install -y \
   jq \
   less \
   $ADDITIONAL_APT_PACKAGES
+
+RUN curl -sSLo install.sh https://install.hclq.sh && \
+  sh install.sh && \
+  rm install.sh
+
 USER $USERNAME
 
 # Gists


### PR DESCRIPTION
This PR adds `hclq` to the devcontainer by the recommendation of issue 9