### PR TITLE
Fix(13): Create VS Code mount paths

### DIFF
--- a/src/Dockerfile.dev
+++ b/src/Dockerfile.dev
@@ -37,6 +37,8 @@ COPY $ADDITIONAL_PROVISIONING_SCRIPT /scripts/provisioning.sh
 RUN if [ -f /scripts/provisioning.sh ]; then /scripts/provisioning.sh; fi
 
 USER $USERNAME
+RUN mkdir -p $HOME/.vscode-server/extensions
+RUN mkdir -p $HOME/.vscode-server-insiders/extensions
 
 # Gists
 ADD --chown=${USERNAME}:${GROUP} \


### PR DESCRIPTION
- Add mount paths for vscode:
  * `$HOME/.vscode-server/extensions`
  * `$HOME/.vscode-server-insiders/extensions`
  To `Dockerfile.dev:40`. This fixes #13 by ensuring these paths are
  inside the container with the right user permissions.
