### PR TITLE
Feat: Update devcontainer tools

### DIFF
--- a/src/Dockerfile.dev
+++ b/src/Dockerfile.dev
@@ -19,16 +19,24 @@ RUN usermod -m -d $HOME $USERNAME
 RUN echo "root:$ROOT_PASS" | chpasswd
 
 RUN apt update && apt install -y \
-  vim \
   jq \
   less \
   git-crypt \
   $ADDITIONAL_APT_PACKAGES
 
+# Yq requires manual retrieval of the package
 RUN wget \
   https://github.com/mikefarah/yq/releases/download/$YQ_VERSION/yq_linux_amd64 \
   -O /usr/bin/yq && \
   chmod +x /usr/bin/yq
+
+# Neovim requires manual retrieval of the latest version
+# as the apt package is quite old
+RUN wget https://github.com/neovim/neovim/releases/download/v0.8.0/nvim-linux64.deb \
+  -O /neovim.deb
+RUN apt install -y /neovim.deb 
+RUN rm /neovim.deb
+ENV EDITOR=nvim
 
 RUN curl -sSLo install.sh https://install.hclq.sh && \
   sh install.sh && \


### PR DESCRIPTION
- Replace 'vim' with 'nvim'. This is done because nvim integrates with
  vscode and acts as a server.
