### PR TITLE
Feat: Infracost & Elam

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -22,8 +22,9 @@ jobs:
     strategy:
       matrix:
         images:
-          - dockerfile: src/Dockerfile.dev
-            base_image_tag: "1.2"
+          - enabled: false
+            dockerfile: src/Dockerfile.dev
+            base_image_tag: "1.4"
             image_name: tf-devcontainer
             devcontainer_subfolder: src/vanilla
             docker_hub_repo_readme_file_path: src/vanilla/DOCKER_README.md
@@ -34,8 +35,9 @@ jobs:
             additional_apt_packages: ""
             additional_provisioning_script: ""
 
-          - dockerfile: src/Dockerfile.dev
-            base_image_tag: "1.2"
+          - enabled: true
+            dockerfile: src/Dockerfile.dev
+            base_image_tag: "1.4"
             image_name: tf-k8s-devcontainer
             devcontainer_subfolder: src/k8s
             docker_hub_repo_readme_file_path: src/k8s/DOCKER_README.md
@@ -45,21 +47,6 @@ jobs:
               src/k8s/**
             additional_apt_packages: ""
             additional_provisioning_script: "src/k8s/provisioning.sh"
-
-          - dockerfile: src/Dockerfile.dev
-            base_image_tag: "1.2"
-            image_name: tf-eks-devcontainer
-            devcontainer_subfolder: src/eks
-            docker_hub_repo_readme_file_path: src/eks/DOCKER_README.md
-            docker_hub_repo_short_description: |
-              Devcontainer for AWS EKS workloads that run on Terraform and Terratest
-            additional_files_to_watch: |
-              src/eks/**
-            # Groff is needed because without it, AWS cli documentation doesn't
-            # work as expected
-            additional_apt_packages: |
-              groff
-            additional_provisioning_script: ""
 
     steps:
       - name: Checkout code
@@ -73,26 +60,23 @@ jobs:
         with:
           files: |
             ${{ matrix.images.dockerfile }}
-            ${{ matrix.images.additional_files_to_watch }}
+            ${{ matrix.images.additionalFilesToWatch }}
             .github/workflows/build-and-push.yml
-
-      - name: Get latest tag
-        id: latest_tag
-        uses: WyriHaximus/github-action-get-previous-tag@v1
-        with:
-          fallback: tag-unavailable
 
       - name: Declare run state
         id: run_state
         run: |
-          if [ ${{ steps.changed_files.outputs.any_modified }} == true ] || \
-            [ ${{ github.event_name }} == workflow_dispatch ] || \
-            [ ${{ steps.latest_tag.outputs.tag }} != tag-unavailable ];
+          if [ ${{ github.ref_type }} == tag ] && \
+             [ ${{ matrix.images.enabled }} == 'true' ] && \
+            ( \
+              [ ${{ steps.changed_files.outputs.any_modified }} == true ] || \
+              [ ${{ github.event_name }} == workflow_dispatch ] \
+            );
           then
-            echo "::set-output name=run_docker_build::true"
+            echo "run_docker_build=true" >> $GITHUB_OUTPUT
             echo "::debug::Docker build will carry out as expected."
           else
-            echo "::set-output name=run_docker_build::false"
+            echo "run_docker_build=false" >> $GITHUB_OUTPUT
             echo "Docker build is cancelled as the required conditions for a run haven't been met"
           fi
 
@@ -100,10 +84,10 @@ jobs:
         if: steps.run_state.outputs.run_docker_build == 'true'
         id: variables
         run: |
-          repo_tag=${{ steps.latest_tag.outputs.tag }}
+          repo_tag=${{ github.ref_name }}
           image_tag=${{ matrix.images.base_image_tag }}.${repo_tag//\//-}
-          image_ref=${{ matrix.images.image_name }}:$image_tag
-          echo "::set-output name=image_tag::$image_tag"
+          image_ref=${{ matrix.images.containerName }}:$image_tag
+          echo "image_tag=$image_tag" >> $GITHUB_OUTPUT
 
       - name: Build and push ${{ steps.variables.outputs.image_ref }}
         if: steps.run_state.outputs.run_docker_build == 'true'
@@ -125,12 +109,3 @@ jobs:
             ${{ matrix.images.docker_hub_repo_short_description }}
           docker_hub_repo_readme_file_path: |
             ${{ matrix.images.docker_hub_repo_readme_file_path }}
-
-      - name: Telegram notifications
-        if: always()
-        uses: utkusarioglu/telegram-notifications@main
-        with:
-          telegram_id: ${{ secrets.TELEGRAM_ID }}
-          telegram_token: ${{ secrets.TELEGRAM_TOKEN }}
-          job_status: ${{ job.status }}
-          github_context: ${{ toJson(github) }}

--- a/src/Dockerfile.dev
+++ b/src/Dockerfile.dev
@@ -11,6 +11,10 @@ ARG HOME=/home/$USERNAME
 ARG ADDITIONAL_APT_PACKAGES
 ARG ADDITIONAL_PROVISIONING_SCRIPT
 ARG YQ_VERSION="v4.28.1"
+ARG NVIM_VERSION="v0.8.3"
+ARG GO_VERSION="1.20.6"
+
+ARG ELAM_ABSPATH="$HOME/elam"
 
 USER root
 
@@ -21,8 +25,13 @@ RUN echo "root:$ROOT_PASS" | chpasswd
 RUN apt update && apt install -y \
   jq \
   less \
-  git-crypt \
+  zip \
   $ADDITIONAL_APT_PACKAGES
+  # git-crypt \
+
+RUN wget "https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz" && \
+   rm -rf /usr/local/go && \
+   tar -C /usr/local -xzf "go$GO_VERSION.linux-amd64.tar.gz"
 
 # Yq requires manual retrieval of the package
 RUN wget \
@@ -31,16 +40,25 @@ RUN wget \
   chmod +x /usr/bin/yq
 
 # Neovim requires manual retrieval of the latest version
-# as the apt package is quite old
-RUN wget https://github.com/neovim/neovim/releases/download/v0.8.0/nvim-linux64.deb \
+# as the apt package and devcontainer feature is quite old
+RUN wget https://github.com/neovim/neovim/releases/download/$NVIM_VERSION/nvim-linux64.deb \
   -O /neovim.deb
 RUN apt install -y /neovim.deb 
 RUN rm /neovim.deb
 ENV EDITOR=nvim
 
+# Elam
+RUN git clone https://github.com/utkusarioglu/elam.git $ELAM_ABSPATH
+
+# hclq is not available in devcontainer features
 RUN curl -sSLo install.sh https://install.hclq.sh && \
   sh install.sh && \
   rm install.sh
+
+# infracost
+RUN curl -fsSL https://raw.githubusercontent.com/infracost/infracost/master/scripts/install.sh | sh
+RUN mkdir -p $HOME/.config/infracost
+RUN chown -R $USERNAME:$GROUP $HOME/.config
 
 COPY $ADDITIONAL_PROVISIONING_SCRIPT /scripts/provisioning.sh
 RUN if [ -f /scripts/provisioning.sh ]; then /scripts/provisioning.sh; fi
@@ -59,6 +77,9 @@ ADD --chown=${USERNAME}:${GROUP} \
 ADD --chown=${USERNAME}:${GROUP} \
   https://gist.githubusercontent.com/utkusarioglu/d5c216c744460c45bf6260d0de4131b4/raw/.inputrc \
   $HOME/.inputrc
+
+# This makes elam easier to use
+RUN echo "alias elam=$ELAM_ABSPATH/elam.sh" >> $HOME/.bash_aliases
 
 RUN chmod +x \
   /scripts/create-env-example.sh \

--- a/src/k8s/.devcontainer/devcontainer.json
+++ b/src/k8s/.devcontainer/devcontainer.json
@@ -1,17 +1,18 @@
 {
   "image": "${localEnv:IMAGE_NAME}:${localEnv:IMAGE_TAG}",
   "features": {
-    "github-cli": "latest",
+    "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/sshd:1": {
       "version": "latest"
     },
-    "kubectl-helm-minikube": {
-      "kubectl": "latest",
-      "helm": "latest",
-      "minikube": "none",
-      "non-root": "automatic"
+    "ghcr.io/devcontainers/features/terraform:1": {
+      "installTFsec": true,
+      "installTerraformDocs": true
     },
-    "ghcr.io/devcontainers/features/docker-from-docker:1": {
+    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+      "minikube": "none"
+    },
+    "ghcr.io/devcontainers/features/aws-cli:1": {
       "version": "latest"
     }
   }

--- a/src/vanilla/.devcontainer/devcontainer.json
+++ b/src/vanilla/.devcontainer/devcontainer.json
@@ -1,9 +1,13 @@
 {
   "image": "${localEnv:IMAGE_NAME}:${localEnv:IMAGE_TAG}",
   "features": {
-    "github-cli": "latest",
+    "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/sshd:1": {
       "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/terraform:1": {
+      "installTFsec": true,
+      "installTerraformDocs": true
     }
   }
 }


### PR DESCRIPTION
- Install infracost to the devcontainer
- Refactor dockerfile to keep versioning for go and nvim as variables,
  this way it's easier to notice and change the version of these tools.
- Install Elam to the devcontainer, now the repo template doesn't need
  to provide elam submodule.
- Remove CI definition for eks devcontainer. Functionality of this
  feature can easily be captured by terragrunt. Same shall be the fate
  for the vanilla image as well in a future commit.
